### PR TITLE
Copier version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,7 @@ RUN set -eux; \
   # Install gcc and libraries needed for building regex during pip install step
   apk add --no-cache \
     gcc=~10.3 \
-    musl-dev=~1.2; \
-  # Install copier
-  pip install --no-cache-dir copier==5.1.0; \
-  apk del \
-    gcc \
-    musl-dev
+    musl-dev=~1.2;
 #################### /builder ####################
 
 #################### final ####################

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,13 @@ FROM update AS builder
 RUN set -eux; \
   # Install gcc and libraries needed for building regex during pip install step
   apk add --no-cache \
-    gcc;
+    gcc \
+    musl-dev; \
+  # Install copier
+  pip install --no-cache-dir copier; \
+  apk del \
+    gcc \
+    musl-dev
 #################### /builder ####################
 
 #################### final ####################
@@ -34,9 +40,9 @@ RUN set -eux; \
 RUN set -eux; \
   apk add --no-cache \
     # Install git, dependency of copier
-    git=~2.42 \
+    git \
     # Install su-exec to drop down from root when running copier
-    su-exec=0.2-r1
+    su-exec
 
 # Copy over python packages and copier script from builder
 COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ FROM update AS builder
 RUN set -eux; \
   # Install gcc and libraries needed for building regex during pip install step
   apk add --no-cache \
-    gcc=~10.3 \
+    gcc=~13.2 \
     musl-dev=~1.2; \
   # Install copier
-  pip install --no-cache-dir copier==5.1.0; \
+  pip install --no-cache-dir copier==8.3.0; \
   apk del \
     gcc \
     musl-dev
@@ -40,7 +40,7 @@ RUN set -eux; \
 RUN set -eux; \
   apk add --no-cache \
     # Install git, dependency of copier
-    git=~2.32 \
+    git=~2.42 \
     # Install su-exec to drop down from root when running copier
     su-exec=0.2-r1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM update AS builder
 RUN set -eux; \
   # Install gcc and libraries needed for building regex during pip install step
   apk add --no-cache \
-    gcc=~13.2 \
+    gcc=~10.3 \
     musl-dev=~1.2; \
   # Install copier
   pip install --no-cache-dir copier==8.3.0; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ FROM update AS builder
 RUN set -eux; \
   # Install gcc and libraries needed for building regex during pip install step
   apk add --no-cache \
-    gcc=~10.3 \
-    musl-dev=~1.2;
+    gcc=~10.3;
 #################### /builder ####################
 
 #################### final ####################

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
     gcc=~10.3 \
     musl-dev=~1.2; \
   # Install copier
-  pip install --no-cache-dir copier==8.3.0; \
+  pip install --no-cache-dir copier==5.1.0; \
   apk del \
     gcc \
     musl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM update AS builder
 RUN set -eux; \
   # Install gcc and libraries needed for building regex during pip install step
   apk add --no-cache \
-    gcc=~10.3;
+    gcc;
 #################### /builder ####################
 
 #################### final ####################


### PR DESCRIPTION
Use Copier 8.3.0
Also update version of other installed packages.

NOTE: removed version constraints for debugging.